### PR TITLE
Add gender to update raceclass

### DIFF
--- a/event_service_gui/templates/raceclasses.html
+++ b/event_service_gui/templates/raceclasses.html
@@ -226,6 +226,11 @@
               <td>Info: Årsklasser hentes fra påmeldingssystemet og kan ikke endres.</td>
             </tr>
             <tr>
+              <td>Kjønn</td>
+              <td><input type=text class="form-control" name="gender" value="{{ klasse.gender }}"></td>
+              <td></td>
+            </tr>
+            <tr>
               <td>Distanse</td>
               <td><input type=text class="form-control" name="distance" value="{{ klasse.distance }}"></td>
               <td></td>

--- a/event_service_gui/views/raceclasses.py
+++ b/event_service_gui/views/raceclasses.py
@@ -185,6 +185,7 @@ async def update_one(user: dict, event_id: str, form: dict) -> str:
     ageclasses = ast.literal_eval(ageclasses_str)
     request_body = {
         "name": str(form["name"]),
+        "gender": str(form["gender"]),
         "distance": str(form["distance"]),
         "event_id": event_id,
         "id": w_id,


### PR DESCRIPTION
Gender was missing from body when updating one raceclass.
This has been fixed in this PR.
